### PR TITLE
Reverse mode (unlink -> ln) for Cloudflare & Superman upstreams

### DIFF
--- a/lib/systemd/user/observer/observe-cloudflare-upstream-conf.service
+++ b/lib/systemd/user/observer/observe-cloudflare-upstream-conf.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/ubuntu/workspace/cron-conf/raspberrypi/bin
-ExecStart=/home/ubuntu/workspace/cron-conf/raspberrypi/bin/observe-dnsmasq-toggle-conf --event create --file cloudflare_upstream.conf --target /etc/dnsmasq.priv/toggle --mode unlink
+ExecStart=/home/ubuntu/workspace/cron-conf/raspberrypi/bin/observe-dnsmasq-toggle-conf --event move,delete --file cloudflare_upstream.conf --source /home/ubuntu/workspace/dnsmasq-conf/dnsmasq/dnsmasq.priv/toggle --target /etc/dnsmasq.priv/toggle --mode ln
 TimeoutSec=15
 Restart=always
 

--- a/lib/systemd/user/observer/observe-superman-upstream-conf.service
+++ b/lib/systemd/user/observer/observe-superman-upstream-conf.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/home/ubuntu/workspace/cron-conf/raspberrypi/bin
-ExecStart=/home/ubuntu/workspace/cron-conf/raspberrypi/bin/observe-dnsmasq-toggle-conf --event create --file superman_upstream.conf --target /etc/dnsmasq.priv/toggle --mode unlink
+ExecStart=/home/ubuntu/workspace/cron-conf/raspberrypi/bin/observe-dnsmasq-toggle-conf --event move,delete --file superman_upstream.conf --source /home/ubuntu/workspace/dnsmasq-conf/dnsmasq/dnsmasq.priv/toggle --target /etc/dnsmasq.priv/toggle --mode ln
 TimeoutSec=15
 Restart=always
 


### PR DESCRIPTION
cf. [Fix upstream vanishment](https://github.com/noraworld/cron-conf/pull/24)